### PR TITLE
Added Released property to RequestViewModel. Added Released filter to…

### DIFF
--- a/PlexRequests.UI/Content/requests.js
+++ b/PlexRequests.UI/Content/requests.js
@@ -540,6 +540,7 @@ function buildRequestContext(result, type) {
         requestedUsers: result.requestedUsers ? result.requestedUsers.join(', ') : '',
         requestedDate: Humanize(result.requestedDate),
         requestedDateTicks: result.requestedDateTicks,
+        released: result.released,
         available: result.available,
         admin: result.admin,
         issues: result.issues,

--- a/PlexRequests.UI/Models/RequestViewModel.cs
+++ b/PlexRequests.UI/Models/RequestViewModel.cs
@@ -39,6 +39,7 @@ namespace PlexRequests.UI.Models
         public string PosterPath { get; set; }
         public DateTime ReleaseDate { get; set; }
         public long ReleaseDateTicks { get; set; }
+        public bool Released { get; set; }
         public RequestType Type { get; set; }
         public string Status { get; set; }
         public bool Approved { get; set; }

--- a/PlexRequests.UI/Modules/RequestsModule.cs
+++ b/PlexRequests.UI/Modules/RequestsModule.cs
@@ -152,8 +152,10 @@ namespace PlexRequests.UI.Modules
 
             var viewModel = dbMovies.Select(movie =>
             {
+
                 return new RequestViewModel
                 {
+					
                     ProviderId = movie.ProviderId,
                     Type = movie.Type,
                     Status = movie.Status,
@@ -163,6 +165,7 @@ namespace PlexRequests.UI.Modules
                     ReleaseDate = movie.ReleaseDate,
                     ReleaseDateTicks = movie.ReleaseDate.Ticks,
                     RequestedDate = movie.RequestedDate,
+					Released = DateTime.Now > movie.ReleaseDate,
                     RequestedDateTicks = DateTimeHelper.OffsetUTCDateTime(movie.RequestedDate, DateTimeOffset).Ticks,
                     Approved = movie.Available || movie.Approved,
                     Title = movie.Title,
@@ -246,7 +249,8 @@ namespace PlexRequests.UI.Modules
                     ReleaseDateTicks = tv.ReleaseDate.Ticks,
                     RequestedDate = tv.RequestedDate,
                     RequestedDateTicks = DateTimeHelper.OffsetUTCDateTime(tv.RequestedDate, DateTimeOffset).Ticks,
-                    Approved = tv.Available || tv.Approved,
+					Released = DateTime.Now > tv.ReleaseDate,
+					Approved = tv.Available || tv.Approved,
                     Title = tv.Title,
                     Overview = tv.Overview,
                     RequestedUsers = isAdmin ? tv.AllUsers.ToArray() : new string[] { },
@@ -288,6 +292,7 @@ namespace PlexRequests.UI.Modules
                     ReleaseDateTicks = album.ReleaseDate.Ticks,
                     RequestedDate = album.RequestedDate,
                     RequestedDateTicks = DateTimeHelper.OffsetUTCDateTime(album.RequestedDate, DateTimeOffset).Ticks,
+                    Released = DateTime.Now > album.ReleaseDate,
                     Approved = album.Available || album.Approved,
                     Title = album.Title,
                     Overview = album.Overview,

--- a/PlexRequests.UI/Views/Requests/Index.cshtml
+++ b/PlexRequests.UI/Views/Requests/Index.cshtml
@@ -63,6 +63,8 @@
                             <li><a href="#" class="filter" data-filter=".approved-false"><i class="fa fa-square-o"></i>  Not Approved</a></li>
                             <li><a href="#" class="filter" data-filter=".available-true"><i class="fa fa-square-o"></i>  Available</a></li>
                             <li><a href="#" class="filter" data-filter=".available-false"><i class="fa fa-square-o"></i>  Not Available</a></li>
+                            <li><a href="#" class="filter" data-filter=".released-true"><i class="fa fa-square-o"></i>  Released</a></li>
+                            <li><a href="#" class="filter" data-filter=".released-false"><i class="fa fa-square-o"></i>  Not Released</a></li>
                         </ul>
                     </div>
                     <div class="btn-group">
@@ -125,7 +127,7 @@
 
 
 <script id="search-template" type="text/x-handlebars-template">
-    <div id="{{requestId}}Template" class="mix available-{{available}} approved-{{approved}}" data-requestorder="{{requestedDateTicks}}" data-releaseorder="{{releaseDateTicks}}">
+    <div id="{{requestId}}Template" class="mix available-{{available}} approved-{{approved}} released-{{released}}" data-requestorder="{{requestedDateTicks}}" data-releaseorder="{{releaseDateTicks}}">
         <div class="row">
             <div class="col-sm-2">
                 {{#if_eq type "movie"}}


### PR DESCRIPTION
… Requests page and hooked it up to the handlebars template. This is in relation to the feature request [here](https://github.com/tidusjar/PlexRequests.Net/issues/160). Check boxes havent been implemented like the request asks, but it's not possible to filter on released items in the list.
