### PR TITLE
Use HTTPS for accessing the poster images

### DIFF
--- a/PlexRequests.UI/Views/Requests/Index.cshtml
+++ b/PlexRequests.UI/Views/Requests/Index.cshtml
@@ -132,7 +132,7 @@
             <div class="col-sm-2">
                 {{#if_eq type "movie"}}
                 {{#if posterPath}}
-                <img class="img-responsive" src="http://image.tmdb.org/t/p/w150/{{posterPath}}" alt="poster">
+                <img class="img-responsive" src="https://image.tmdb.org/t/p/w150/{{posterPath}}" alt="poster">
                 {{/if}}
                 {{/if_eq}}
                 {{#if_eq type "tv"}}


### PR DESCRIPTION
When serving PlexRequests.Net using a reverse proxy that uses HTTPS, poster images make the requests page 'insecure' because they are loading from an HTTP host. This host also supports HTTPS, so it should use HTTPS instead.