### PR TITLE
Use HTTPS for the poster images

### DIFF
--- a/PlexRequests.UI/Modules/SearchModule.cs
+++ b/PlexRequests.UI/Modules/SearchModule.cs
@@ -473,7 +473,7 @@ namespace PlexRequests.UI.Modules
                 Type = RequestType.Movie,
                 Overview = movieInfo.Overview,
                 ImdbId = movieInfo.ImdbId,
-                PosterPath = "http://image.tmdb.org/t/p/w150/" + movieInfo.PosterPath,
+                PosterPath = "https://image.tmdb.org/t/p/w150/" + movieInfo.PosterPath,
                 Title = movieInfo.Title,
                 ReleaseDate = movieInfo.ReleaseDate ?? DateTime.MinValue,
                 Status = movieInfo.Status,

--- a/PlexRequests.UI/Views/Requests/Index.cshtml
+++ b/PlexRequests.UI/Views/Requests/Index.cshtml
@@ -132,7 +132,7 @@
             <div class="col-sm-2">
                 {{#if_eq type "movie"}}
                 {{#if posterPath}}
-                <img class="img-responsive" src="http://image.tmdb.org/t/p/w150/{{posterPath}}" alt="poster">
+                <img class="img-responsive" src="https://image.tmdb.org/t/p/w150/{{posterPath}}" alt="poster">
                 {{/if}}
                 {{/if_eq}}
                 {{#if_eq type "tv"}}

--- a/PlexRequests.UI/Views/Search/Index.cshtml
+++ b/PlexRequests.UI/Views/Search/Index.cshtml
@@ -144,7 +144,7 @@
 
             {{#if_eq type "movie"}}
             {{#if posterPath}}
-            <img class="img-responsive" src="http://image.tmdb.org/t/p/w150/{{posterPath}}" alt="poster">
+            <img class="img-responsive" src="https://image.tmdb.org/t/p/w150/{{posterPath}}" alt="poster">
             {{/if}}
             {{/if_eq}}
             {{#if_eq type "tv"}}


### PR DESCRIPTION
Use HTTPS for poster images, this removes the mixed-content warnings when serving the application via an HTTPS reverse proxy