### PR TITLE
Set meta charset to be utf-8

### DIFF
--- a/PlexRequests.UI/Views/Shared/Partial/_Head.cshtml
+++ b/PlexRequests.UI/Views/Shared/Partial/_Head.cshtml
@@ -19,6 +19,7 @@
 <div hidden="hidden" id="baseUrl">@baseUrl.ToHtmlString()</div>
 <head>
     <title>@UI.Layout_Title</title>
+    <meta charset="utf-8">
     <!-- Styles -->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     @Html.LoadAnalytics()


### PR DESCRIPTION
This fixes issue #537 where the navigation wouldn't have the correct encoding hence not displaying åäö and other characters correctly.

Solved by setting encoding to be utf-8. 