### PR TITLE
Added Paypalme options, no UI yet

### DIFF
--- a/PlexRequests.Core/SettingModels/PlexRequestSettings.cs
+++ b/PlexRequests.Core/SettingModels/PlexRequestSettings.cs
@@ -58,8 +58,9 @@ namespace PlexRequests.Core.SettingModels
         public bool Wizard { get; set; }
         public bool DisableTvRequestsByEpisode { get; set; }
         public bool DisableTvRequestsBySeason { get; set; }
-        public string PayPalMeName { get; set; }
-        public bool EnablePayPalMe { get; set; }
+        public string CustomDonationUrl { get; set; }
+        public bool EnableCustomDonationUrl { get; set; }
+        public string CustomDonationMessage { get; set; }
         /// <summary>
         /// The CSS name of the theme we want
         /// </summary>

--- a/PlexRequests.Core/SettingModels/PlexRequestSettings.cs
+++ b/PlexRequests.Core/SettingModels/PlexRequestSettings.cs
@@ -58,7 +58,8 @@ namespace PlexRequests.Core.SettingModels
         public bool Wizard { get; set; }
         public bool DisableTvRequestsByEpisode { get; set; }
         public bool DisableTvRequestsBySeason { get; set; }
-
+        public string PayPalMeName { get; set; }
+        public bool EnablePayPalMe { get; set; }
         /// <summary>
         /// The CSS name of the theme we want
         /// </summary>

--- a/PlexRequests.UI/Modules/DonationLinkModule.cs
+++ b/PlexRequests.UI/Modules/DonationLinkModule.cs
@@ -50,7 +50,7 @@ namespace PlexRequests.UI.Modules
                 Log.Warn("Exception Thrown when attempting to check the custom donation url");
                 Log.Warn(e);
                 JObject o = new JObject();
-                o["url"] = "https://www.paypal.me/PlexRequestsNet";
+                o["url"] = "donationLinkError";
                 o["message"] = "\"" + "Donate to Library Maintainer" + "\"";
                 return Response.AsJson(o);
             }

--- a/PlexRequests.UI/Modules/DonationLinkModule.cs
+++ b/PlexRequests.UI/Modules/DonationLinkModule.cs
@@ -28,31 +28,23 @@ namespace PlexRequests.UI.Modules
 
         private async Task<Response> GetCustomDonationUrl(ISettingsService<PlexRequestSettings> pr)
         {
-            PlexRequestSettings settings = pr.GetSettings();
+            PlexRequestSettings settings = await pr.GetSettingsAsync();
             try
             {
                 if (settings.EnableCustomDonationUrl)
                 {
-                    JObject o = new JObject();
-                    o["url"] = "\""+ settings.CustomDonationUrl + "\"";
-                    o["message"] = "\"" + settings.CustomDonationMessage + "\"";
-                    return Response.AsJson(o);
+                    return Response.AsJson(new { url = settings.CustomDonationUrl, message = settings.CustomDonationMessage });
                 }
                 else
                 {
-                    JObject o = new JObject();
-                    o["url"] = "https://www.paypal.me/PlexRequestsNet";
-                    return Response.AsJson(o);
+                    return Response.AsJson(new { url = settings.CustomDonationUrl, message = settings.CustomDonationMessage });
                 }
             }
             catch (Exception e)
             {
                 Log.Warn("Exception Thrown when attempting to check the custom donation url");
                 Log.Warn(e);
-                JObject o = new JObject();
-                o["url"] = "donationLinkError";
-                o["message"] = "\"" + "Donate to Library Maintainer" + "\"";
-                return Response.AsJson(o);
+                return Response.AsJson(new { url = settings.CustomDonationUrl, message = settings.CustomDonationMessage });
             }
         }
     }

--- a/PlexRequests.UI/Modules/DonationLinkModule.cs
+++ b/PlexRequests.UI/Modules/DonationLinkModule.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Threading.Tasks;
+
+using Nancy;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NLog;
+
+using PlexRequests.Core;
+using PlexRequests.Core.SettingModels;
+using PlexRequests.Helpers;
+using PlexRequests.UI.Models;
+
+namespace PlexRequests.UI.Modules
+{
+    public class DonationLinkModule : BaseAuthModule
+    {
+        public DonationLinkModule(ICacheProvider provider, ISettingsService<PlexRequestSettings> pr) : base("customDonation", pr)
+        {
+            Cache = provider;
+
+            Get["/", true] = async (x, ct) => await GetCustomDonationUrl(pr);
+        }
+
+        private ICacheProvider Cache { get; }
+
+        private static Logger Log = LogManager.GetCurrentClassLogger();
+
+        private async Task<Response> GetCustomDonationUrl(ISettingsService<PlexRequestSettings> pr)
+        {
+            PlexRequestSettings settings = pr.GetSettings();
+            try
+            {
+                if (settings.EnableCustomDonationUrl)
+                {
+                    JObject o = new JObject();
+                    o["url"] = "\""+ settings.CustomDonationUrl + "\"";
+                    o["message"] = "\"" + settings.CustomDonationMessage + "\"";
+                    return Response.AsJson(o);
+                }
+                else
+                {
+                    JObject o = new JObject();
+                    o["url"] = "https://www.paypal.me/PlexRequestsNet";
+                    return Response.AsJson(o);
+                }
+            }
+            catch (Exception e)
+            {
+                Log.Warn("Exception Thrown when attempting to check the custom donation url");
+                Log.Warn(e);
+                JObject o = new JObject();
+                o["url"] = "https://www.paypal.me/PlexRequestsNet";
+                o["message"] = "\"" + "Donate to Library Maintainer" + "\"";
+                return Response.AsJson(o);
+            }
+        }
+    }
+    
+}

--- a/PlexRequests.UI/PlexRequests.UI.csproj
+++ b/PlexRequests.UI/PlexRequests.UI.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Modules\BaseModule.cs" />
     <Compile Include="Modules\BetaModule.cs" />
     <Compile Include="Modules\CultureModule.cs" />
+    <Compile Include="Modules\DonationLinkModule.cs" />
     <Compile Include="Modules\IssuesModule.cs" />
     <Compile Include="Modules\LandingPageModule.cs" />
     <Compile Include="Modules\RequestsBetaModule.cs" />

--- a/PlexRequests.UI/Resources/UI.resx
+++ b/PlexRequests.UI/Resources/UI.resx
@@ -443,4 +443,7 @@
   <data name="Search_ViewInPlex" xml:space="preserve">
     <value>View In Plex</value>
   </data>
+  <data name="Custom_Donation_Default" xml:space="preserve">
+    <value>Donate to Library Maintainer</value>
+  </data>
 </root>

--- a/PlexRequests.UI/Resources/UI1.Designer.cs
+++ b/PlexRequests.UI/Resources/UI1.Designer.cs
@@ -115,6 +115,15 @@ namespace PlexRequests.UI.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Donate to Library Maintainer.
+        /// </summary>
+        public static string Custom_Donation_Default {
+            get {
+                return ResourceManager.GetString("Custom_Donation_Default", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Issue.
         /// </summary>
         public static string Issues_Issue {

--- a/PlexRequests.UI/Views/Admin/Settings.cshtml
+++ b/PlexRequests.UI/Views/Admin/Settings.cshtml
@@ -253,10 +253,31 @@
                     }
                 </div>
             </div>
+            <div class="form-group">
+                <div class="checkbox">
+
+                    @if (Model.EnablePayPalMe)
+                    {
+                        <input type="checkbox" id="EnablePayPalMe" name="EnablePayPalMe" checked="checked">
+                        <label for="EnablePayPalMe">Enable custom paypal.me link</label>
+                    }
+                    else
+                    {
+                        <input type="checkbox" id="EnablePayPalMe" name="EnablePayPalMe"><label for="EnablePayPalMe">Enable custom paypal.me donate link</label>
+                    }
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="PayPalMeName" class="control-label">Paypal.me name</label>
+                <div>
+                    <input type="text" class="form-control-custom form-control " id="PayPalMeName" name="PayPalMeName" placeholder="paypay.me name" value="@Model.PayPalMeName">
+                </div>
+            </div>
+ 
 
 
 
-            <p class="form-group">A comma separated list of users whose requests do not require approval (These users also do not have a request limit).</p>
+
             <div class="form-group">
                 <label for="NoApprovalUsers" class="control-label">Approval White listed Users</label>
                 <div>

--- a/PlexRequests.UI/Views/Admin/Settings.cshtml
+++ b/PlexRequests.UI/Views/Admin/Settings.cshtml
@@ -287,13 +287,13 @@
             <div class="form-group">
                 <label for="CustomDonationUrl" class="control-label">Custom Donation URL</label>
                 <div>
-                    <input type="text" class="form-control-custom form-control " id="CustomDonationUrl" name="CustomDonationUrl" placeholder="Custom URL" value="@Model.CustomDonationUrl">
+                    <input type="text" class="form-control-custom form-control " id="CustomDonationUrl" name="CustomDonationUrl" placeholder="http://example.com" value="@Model.CustomDonationUrl">
                 </div>
             </div>
             <div class="form-group">
-                <label for="CustomDonationMessage" class="control-label">Custom Donation Message</label>
+                <label for="CustomDonationMessage" class="control-label">Donation Button Message</label>
                 <div>
-                    <input type="text" class="form-control-custom form-control " id="CustomDonationMessage" name="CustomDonationMessage" placeholder="Custom Donation Message" value="@Model.CustomDonationMessage">
+                    <input type="text" class="form-control-custom form-control " id="CustomDonationMessage" name="CustomDonationMessage" placeholder="Donation button message" value="@Model.CustomDonationMessage">
                 </div>
             </div>
  

--- a/PlexRequests.UI/Views/Admin/Settings.cshtml
+++ b/PlexRequests.UI/Views/Admin/Settings.cshtml
@@ -256,21 +256,27 @@
             <div class="form-group">
                 <div class="checkbox">
 
-                    @if (Model.EnablePayPalMe)
+                    @if (Model.EnableCustomDonationUrl)
                     {
-                        <input type="checkbox" id="EnablePayPalMe" name="EnablePayPalMe" checked="checked">
-                        <label for="EnablePayPalMe">Enable custom paypal.me link</label>
+                        <input type="checkbox" id="EnableCustomDonationUrl" name="EnableCustomDonationUrl" checked="checked">
+                        <label for="EnableCustomDonationUrl">Enable custom donation link</label>
                     }
                     else
                     {
-                        <input type="checkbox" id="EnablePayPalMe" name="EnablePayPalMe"><label for="EnablePayPalMe">Enable custom paypal.me donate link</label>
+                        <input type="checkbox" id="EnableCustomDonationUrl" name="EnableCustomDonationUrl"><label for="EnableCustomDonationUrl">Enable custom donation link</label>
                     }
                 </div>
             </div>
             <div class="form-group">
-                <label for="PayPalMeName" class="control-label">Paypal.me name</label>
+                <label for="CustomDonationUrl" class="control-label">Custom Donation URL</label>
                 <div>
-                    <input type="text" class="form-control-custom form-control " id="PayPalMeName" name="PayPalMeName" placeholder="paypay.me name" value="@Model.PayPalMeName">
+                    <input type="text" class="form-control-custom form-control " id="CustomDonationUrl" name="CustomDonationUrl" placeholder="Custom URL" value="@Model.CustomDonationUrl">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="CustomDonationMessage" class="control-label">Custom Donation Message</label>
+                <div>
+                    <input type="text" class="form-control-custom form-control " id="CustomDonationMessage" name="CustomDonationMessage" placeholder="Custom Donation Message" value="@Model.CustomDonationMessage">
                 </div>
             </div>
  
@@ -278,6 +284,7 @@
 
 
 
+        <p class="form-group">A comma separated list of users whose requests do not require approval (These users also do not have a request limit).</p>
             <div class="form-group">
                 <label for="NoApprovalUsers" class="control-label">Approval White listed Users</label>
                 <div>

--- a/PlexRequests.UI/Views/Shared/Partial/_Navbar.cshtml
+++ b/PlexRequests.UI/Views/Shared/Partial/_Navbar.cshtml
@@ -39,7 +39,7 @@
                 {
                     <li><a id="donate" href="https://www.paypal.me/PlexRequestsNet" target="_blank"><i class="fa fa-heart" style="color: red"></i> @UI.Layout_Donate</a></li>
                 }
-                <li id="customDonate" style="display: none"><a id="customDonateHref" href="https://www.paypal.me/PlexRequestsNet" target="_blank"><i class="fa fa-heart" style="color: yellow;"></i> <span id="donationText">Donate to Library Maintainer</span></a></li>
+                <li id="customDonate" style="display: none"><a id="customDonateHref" href="https://www.paypal.me/PlexRequestsNet" target="_blank"><i class="fa fa-heart" style="color: yellow;"></i> <span id="donationText">@UI.Custom_Donation_Default</span></a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
 
@@ -94,8 +94,10 @@
         </div>
     </div>
     <script>
+        var base = '@Html.GetBaseUrl()';
+        var url = createBaseUrl(base, '/customDonation');
         $.ajax({
-            url: "/customDonation",
+            url: url,
             success: function (result) {
                 console.log("we win + " + result.url);
                 if (result.url && result.url != "donationLinkError") {

--- a/PlexRequests.UI/Views/Shared/Partial/_Navbar.cshtml
+++ b/PlexRequests.UI/Views/Shared/Partial/_Navbar.cshtml
@@ -1,6 +1,7 @@
 ﻿@using Nancy.Security
 @using Nancy.Session
 @using Nancy;
+@using PlexRequests.Core.SettingModels
 @using PlexRequests.UI.Helpers
 @using PlexRequests.UI.Models
 @using PlexRequests.UI.Resources
@@ -38,10 +39,11 @@
                 {
                     <li><a id="donate" href="https://www.paypal.me/PlexRequestsNet" target="_blank"><i class="fa fa-heart" style="color: red"></i> @UI.Layout_Donate</a></li>
                 }
+                <li id="customDonate" style="display: none"><a id="customDonateHref" href="https://www.paypal.me/PlexRequestsNet" target="_blank"><i class="fa fa-heart" style="color: yellow;"></i> <span id="donationText">Donate to Library Maintainer</span></a></li>
             </ul>
             <ul class="nav navbar-nav navbar-right">
 
-
+               
                 @if (!Context.CurrentUser.IsAuthenticated() && Context.Request.Session[SessionKeys.UsernameKey] == null) // TODO replace with IsAdmin
                 {
 
@@ -91,5 +93,22 @@
             </ul>
         </div>
     </div>
+    <script>
+        $.ajax({
+            url: "/customDonation",
+            success: function (result) {
+                $("#customDonate").show();
+                var donateLink = $("#customDonateHref");
+                var donationText = $("#donationText");
+                donateLink.attr("href", result.url);
+                if(result.message) {
+                    donationText.text(result.message);
+                }
+            },
+            error: function(xhr, status, error) {
+                console.log("error " + error);
+            }
+        });
+    </script>
     <div id="updateAvailable" hidden="hidden"></div>
 </nav>

--- a/PlexRequests.UI/Views/Shared/Partial/_Navbar.cshtml
+++ b/PlexRequests.UI/Views/Shared/Partial/_Navbar.cshtml
@@ -97,16 +97,20 @@
         $.ajax({
             url: "/customDonation",
             success: function (result) {
-                $("#customDonate").show();
-                var donateLink = $("#customDonateHref");
-                var donationText = $("#donationText");
-                donateLink.attr("href", result.url);
-                if(result.message) {
-                    donationText.text(result.message);
+                console.log("we win + " + result.url);
+                if (result.url && result.url != "donationLinkError") {
+                    $("#customDonate").show();
+                    var donateLink = $("#customDonateHref");
+                    var donationText = $("#donationText");
+                    donateLink.attr("href", result.url);
+                    if(result.message) {
+                        donationText.text(result.message);
+                    }
                 }
             },
             error: function(xhr, status, error) {
                 console.log("error " + error);
+                $("#customDonate").hide();
             }
         });
     </script>


### PR DESCRIPTION
I added the options for custom donate button, but the actual implementation of the button its self Im a little unsure on. 

Id like to add a configurable button that shows up next to the existing donate, and have 2
"Donate to PlexRequests" "Donate to *Library Maintainer"

I can see where the existing one is setup in _Navbar, however since thats a partial thats rendered from the layout, Im not sure how to go about getting the data from settings. everything in navbar comes from Context. I think passing a model into layout would be the wrong choice, another option is just an endpoint somewhere that can get fetched and setup with an ajax call. But that also feels too complicated for a simple task. 

All I want/need to do is check the values of the settings, and render a new button if they exist. 