### PR TITLE
Fix boostrapper-datetimepicker imports (#586)

### DIFF
--- a/PlexRequests.UI/Helpers/BaseUrlHelper.cs
+++ b/PlexRequests.UI/Helpers/BaseUrlHelper.cs
@@ -122,8 +122,8 @@ namespace PlexRequests.UI.Helpers
 
             var sb = new StringBuilder();
             var startUrl = $"{content}/Content";
-            sb.AppendLine($"<link rel=\"stylesheet\" href=\"{startUrl}/datepicker.min.css\" type=\"text/css\"/>");
-            sb.AppendLine($"<script src=\"{startUrl}/bootstrap-datetimepicker.min.js\"></script>");
+            sb.AppendLine($"<link rel=\"stylesheet\" href=\"/{startUrl}/datepicker.min.css\" type=\"text/css\"/>");
+            sb.AppendLine($"<script src=\"/{startUrl}/bootstrap-datetimepicker.min.js\"></script>");
 
             return helper.Raw(sb.ToString());
         }


### PR DESCRIPTION
When the base url is set, resource file imports need a forward slash at
the beginning. Since it's missing from the datepicker.min.css link,
the Landing Page fails to load correctly causing odd behavior.